### PR TITLE
Add application/mp4 to isobmff bytestream format

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
     <section id="mime-parameters">
       <h2>MIME-type parameters</h2>
       <p>This section specifies the parameters that can be used in the MIME-type passed to <a def-id="isTypeSupported"></a> or <a def-id="addSourceBuffer"></a>.</p>
-      <p>MIME-types for this specification MUST conform to the rules outlined for "audio/mp4" and "video/mp4" in <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
+      <p>MIME-types for this specification MUST conform to the rules outlined for "audio/mp4", "video/mp4" and "application/mp4" in <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
       </p>
       <div class="note">Implementations MAY only implement a subset of the codecs and profiles mentioned in the RFC.</div>
     </section>


### PR DESCRIPTION
PR copied over from https://github.com/w3c/media-source/pull/257
See discussion in original issue https://github.com/w3c/media-source/issues/197
Also see companion PR against Byte Stream Registry: https://github.com/w3c/mse-byte-stream-format-registry/pull/1

Original author:
+@davemevans


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-isobmff/pull/1.html" title="Last updated on Nov 24, 2020, 1:36 PM UTC (70f21ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-isobmff/1/48be69e...70f21ca.html" title="Last updated on Nov 24, 2020, 1:36 PM UTC (70f21ca)">Diff</a>