### PR TITLE
[Editorial] Refresh xref usage, drop custom script

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 
     <section id="mime-parameters">
       <h2>MIME-type parameters</h2>
-      <p>This section specifies the parameters that can be used in the MIME-type passed to {{MediaSource/isTypeSupported()}} or {{MediaSource/isTypeSupported()}}.</p>
+      <p>This section specifies the parameters that can be used in the MIME-type passed to {{MediaSource/isTypeSupported()}} or {{MediaSource/addSourceBuffer()}}.</p>
       <p>MIME-types for this specification MUST conform to the rules outlined for "audio/mp4" and "video/mp4" in [[RFC6381]].
       </p>
       <div class="note">Implementations MAY only implement a subset of the codecs and profiles mentioned in [[RFC6381]].</div>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 
     <section id="introduction">
       <h2>Introduction</h2>
-      <p>This specification defines segment formats for implementations of [[[MEDIA-SOURCE]]] [[!MEDIA-SOURCE]] that choose to support the ISO Base Media File Format [[!ISOBMFF]].</p>
+      <p>This specification defines segment formats for implementations of [[[MEDIA-SOURCE]]] [[MEDIA-SOURCE]] that choose to support the ISO Base Media File Format [[ISOBMFF]].</p>
       <p>It defines the MIME-type parameters used to signal codecs, and provides
       the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access point=] required by
       the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification.</p>

--- a/index.html
+++ b/index.html
@@ -4,17 +4,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>ISO BMFF Byte Stream Format</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-    <script src="https://w3c.github.io/media-source/media-source.js" class="remove"></script>
-    <script class="remove">
-      (function() {
-        var isobmffContainerSpecDefinitions = {
-          'iso-14496-12': { fragment: 'https://standards.iso.org/ittf/PubliclyAvailableStandards/c061988_ISO_IEC_14496-12_2012.zip', link_text: 'ISO/IEC 14496-12', },
-          'movie-fragment-relative-addressing': { fragment: '#movie-fragment-relative-addressing', link_text: 'movie-fragment relative addressing'}
-        };
-
-        mediaSourceAddDefinitionInfo("isobmff-byte-stream-format", "", isobmffContainerSpecDefinitions);
-      })();
-    </script>
 
     <script class="remove">
       var respecConfig = {
@@ -37,54 +26,11 @@
         { name: "Adrian Bateman (until April 2015)", url: "", company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       ],
 
-      mseDefGroupName: "isobmff-byte-stream-format",
-      mseUnusedGroupNameExcludeList: ["media-source"],
-      mseContributors: [
-        "Steven Robertson",
-        "Kevin Streeter",
-        "Joe Steele",
-        "Michael Thornburgh",
-        "John Simmons",
-        "Jerry Smith",
-        "Cyril Concolato",
-        "David Singer",
-        "Chris Poole",
-        "Jer Noble"
-      ],
+      github: "w3c/mse-byte-stream-format-isobmff",
+      wgPublicList: "public-media-wg",
 
       // name of the WG
-      group: "media",
-
-      scheme: "https",
-
-      otherLinks: [{
-      key: 'Repository',
-      data: [{
-          value: 'We are on GitHub',
-          href: 'https://github.com/w3c/mse-byte-stream-format-isobmff/'
-        }, {
-          value: 'File a bug',
-          href: 'https://github.com/w3c/mse-byte-stream-format-isobmff/issues'
-        }, {
-          value: 'Commit history',
-          href: 'https://github.com/w3c/mse-byte-stream-format-isobmff/commits/main/index.html'
-        }]
-      },{
-        key: 'Mailing list',
-        data: [{
-          value: 'public-media-wg@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
-        }]
-      }],
-
-      preProcess: [ mediaSourceAddMainSpecDefinitionInfos, mediaSourcePreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ mediaSourcePostProcessor ]
-
+      group: "media"
       };
     </script>
     <!-- script to register bugs -->
@@ -101,29 +47,29 @@
     </style>
 
   </head>
-  <body>
+  <body data-cite="html media-source">
     <section id="abstract">
-      This specification defines a <a def-id="mse-spec"></a> [[MEDIA-SOURCE]] byte stream format specification based on the ISO Base Media
-      File Format.
+      <p>This specification defines a [[[MEDIA-SOURCE]]] [[MEDIA-SOURCE]] byte stream format specification based on the ISO Base Media
+      File Format [[ISOBMFF]].</p>
     </section>
 
     <section id="sotd">
       <p>The working group maintains <a href="https://github.com/w3c/mse-byte-stream-format-isobmff/issues">a list of all bug reports that the editors have not yet tried to address</a>;
-      there may also be related open bugs in the [[MEDIA-SOURCE]] repository.</p>
+      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a>.</p>
       <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="introduction">
       <h2>Introduction</h2>
-      <p>This specification defines segment formats for implementations of <a def-id="mse-spec"></a> [[!MEDIA-SOURCE]] that choose to support the ISO Base Media File Format
-  <a def-id="iso-14496-12"></a> [[!ISOBMFF]].</p> It defines the MIME-type parameters used to signal codecs, and provides
-      the necessary format specific definitions for <a def-id="init-segments"></a>, <a def-id="media-segments"></a>, and <a def-id="random-access-points"></a> required by
-      the <a def-id="byte-stream-formats-section"></a> of the Media Source Extensions spec.</p>
+      <p>This specification defines segment formats for implementations of [[[MEDIA-SOURCE]]] [[!MEDIA-SOURCE]] that choose to support the ISO Base Media File Format [[!ISOBMFF]].</p>
+      <p>It defines the MIME-type parameters used to signal codecs, and provides
+      the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access point=] required by
+      the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the Media Source Extensions specification.</p>
     </section>
 
     <section id="mime-parameters">
       <h2>MIME-type parameters</h2>
-      <p>This section specifies the parameters that can be used in the MIME-type passed to <a def-id="isTypeSupported"></a> or <a def-id="addSourceBuffer"></a>.</p>
+      <p>This section specifies the parameters that can be used in the MIME-type passed to {{MediaSource/isTypeSupported()}} or {{MediaSource/isTypeSupported()}}.</p>
       <p>MIME-types for this specification MUST conform to the rules outlined for "audio/mp4" and "video/mp4" in [[RFC6381]].
       </p>
       <div class="note">Implementations MAY only implement a subset of the codecs and profiles mentioned in [[RFC6381]].</div>
@@ -131,9 +77,9 @@
 
     <section id="iso-init-segments">
       <h4>Initialization Segments</h4>
-      <p>An ISO BMFF <a def-id="init-segment"></a> is defined in this specification as a single File Type Box (<span class="iso-box">ftyp</span>) followed by a single Movie Box (<span class="iso-box">moov</span>).</p>
+      <p>An ISO BMFF [=initialization segment=] is defined in this specification as a single File Type Box (<span class="iso-box">ftyp</span>) followed by a single Movie Box (<span class="iso-box">moov</span>).</p>
 
-      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
+      <p>The user agent MUST run the [=append error=] algorithm if any of the following conditions are met:</p>
       <ol>
         <li>A File Type Box contains a <span class="iso-var">major_brand</span> or <span class="iso-var">compatible_brand</span> that the user agent does not support.</li>
         <li>A box or field in the Movie Box is encountered that violates the requirements mandated
@@ -152,35 +98,35 @@
 
       <p>Valid top-level boxes such as <span class="iso-box">pdin</span>, <span class="iso-box">free</span>, and <span class="iso-box">sidx</span> are
         allowed to appear before the <span class="iso-box">moov</span> box. These boxes MUST be accepted and ignored by the user agent and are not
-        considered part of the <a def-id="init-segment"></a> in this specification.</p>
+        considered part of the [=initialization segment=] in this specification.</p>
 
-      <p>The user agent MUST source attribute values for id, kind, label and language for <a def-id="audio-track"></a>, <a def-id="video-track"></a> and
-        <a def-id="text-track"></a> objects as described for MPEG-4 ISOBMFF in the in-band tracks spec [[INBANDTRACKS]].</p>
+      <p>The user agent MUST source attribute values for `id`, `kind`, `label` and `language` for {{AudioTrack}}, {{VideoTrack}} and
+        {{TextTrack}} objects as described for MPEG-4 ISOBMFF in the in-band tracks spec [[INBANDTRACKS]].</p>
     </section>
 
     <section id="iso-media-segments">
       <h4>Media Segments</h4>
-      <p>An ISO BMFF <a def-id="media-segment"></a> is defined in this specification as one optional
+      <p>An ISO BMFF [=media segment=] is defined in this specification as one optional
         Segment Type Box (<span class="iso-box">styp</span>) followed by a single Movie Fragment Box
         (<span class="iso-box">moof</span>) followed by one or more Media Data Boxes (<span class="iso-box">mdat</span>).
         If the Segment Type Box is not present, the segment MUST conform to the brands listed in the
-        File Type Box (<span class="iso-box">ftyp</span>) in the <a def-id="init-segment"></a>.</p>
-      <p>Valid top-level boxes defined in <a def-id="iso-14496-12"></a> other than <span class="iso-box">ftyp</span>,
+        File Type Box (<span class="iso-box">ftyp</span>) in the [=initialization segment=].</p>
+      <p>Valid top-level boxes defined in [[ISOBMFF]] other than <span class="iso-box">ftyp</span>,
         <span class="iso-box">moov</span>, <span class="iso-box">styp</span>, <span class="iso-box">moof</span>, and <span class="iso-box">mdat</span> are allowed to appear between the end of an
-        <a def-id="init-segment"></a> or <a def-id="media-segment"></a> and before the beginning of a new <a def-id="media-segment"></a>.
-        These boxes MUST be accepted and ignored by the user agent and are not considered part of the <a def-id="media-segment"></a> in this
+        [=initialization segment=] or [=media segment=] and before the beginning of a new [=media segment=].
+        These boxes MUST be accepted and ignored by the user agent and are not considered part of the [=media segment=] in this
         specification.
       </p>
 
-      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
+      <p>The user agent MUST run the [=append error=] algorithm if any of the following conditions are met:</p>
       <ol>
         <li>A box or field in the Movie Fragment Box is encountered that violates the requirements mandated
           by the <span class="iso-var">major_brand</span> or one of the
           <span class="iso-var">compatible_brands</span> in the Segment Type Box in this
-          <a def-id="media-segment"></a> or the File Type Box in the <a def-id="init-segment"></a> if a
+          [=media segment=] or the File Type Box in the [=initialization segment=] if a
           Segment Type Box is not present.</li>
-        <li>This <a def-id="media-segment"></a> contains a Segment Type Box that is not compatible with the
-          File Type Box in the <a def-id="init-segment"></a>.</li>
+        <li>This [=media segment=] contains a Segment Type Box that is not compatible with the
+          File Type Box in the [=initialization segment=].</li>
   <li>The Movie Fragment Box does not contain at least one Track Fragment Box (<span class="iso-box">traf</span>).</li>
   <li>The Movie Fragment Box does not use <a>movie-fragment relative addressing</a>.</li>
   <li>External data references are being used.</li>
@@ -204,14 +150,25 @@
 
     <section id="iso-random-access-points">
       <h4>Random Access Points</h4>
-      <p>A <a def-id="random-access-point"></a> as defined in this specification corresponds to a Stream Access Point of type 1 or 2 as defined in Annex I of <a def-id="iso-14496-12"></a>.</p>
+      <p>A [=random access point=] as defined in this specification corresponds to a Stream Access Point of type 1 or 2 as defined in Annex I of [[ISOBMFF]].</p>
     </section>
 
     <section id="conformance"></section>
 
     <section id="acknowledgements">
       <h2>Acknowledgments</h2>
-      The editors would like to thank <a def-id="contributors"></a> for their contributions to this specification.
+      The editors would like to thank
+
+      Chris Poole,
+      Cyril Concolato,
+      David Singer,
+      Jer Noble,
+      Jerry Smith,
+      Joe Steele,
+      John Simmons,
+      Kevin Streeter,
+      Michael Thornburgh,
+      and Steven Robertson for their contributions to this specification.
     </section>
 
   </body>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
       <p>This specification defines segment formats for implementations of [[[MEDIA-SOURCE]]] [[!MEDIA-SOURCE]] that choose to support the ISO Base Media File Format [[!ISOBMFF]].</p>
       <p>It defines the MIME-type parameters used to signal codecs, and provides
       the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access point=] required by
-      the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the Media Source Extensions specification.</p>
+      the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification.</p>
     </section>
 
     <section id="mime-parameters">

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
       <h2>Introduction</h2>
       <p>This specification defines segment formats for implementations of [[[MEDIA-SOURCE]]] [[MEDIA-SOURCE]] that choose to support the ISO Base Media File Format [[ISOBMFF]].</p>
       <p>It defines the MIME-type parameters used to signal codecs, and provides
-      the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access point=] required by
+      the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access points=] required by
       the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification.</p>
     </section>
 


### PR DESCRIPTION
This refreshes the spec to leverage ReSpec cross-referencing capabilities. See discussion in https://github.com/w3c/media-source/pull/337#issuecomment-1837837578

ReSpec currently (rightfully) issues warnings because some of the MSE terms are defined informatively in MSE, whereas they should rather be defined in a normative section, as noted in https://github.com/w3c/media-source/issues/325#issuecomment-1824830898

Closes #11


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-isobmff/pull/12.html" title="Last updated on Dec 5, 2023, 8:20 PM UTC (b8eecee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-isobmff/12/78e263b...b8eecee.html" title="Last updated on Dec 5, 2023, 8:20 PM UTC (b8eecee)">Diff</a>