### PR TITLE
Refresh list of editors and SOTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,11 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-        { name: "Matthew Wolenetz",  mailto:"matt.wolenetz@gmail.com",
+        { name: "Matthew Wolenetz", mailto: "matt.wolenetz@gmail.com",
           company: "W3C Invited Expert",
           w3cid: "148095" },
-        { name: "Mark Watson", url: "", company: "Netflix Inc.", companyURL: "https://www.netflix.com/",
+        { name: "Mark Watson",
+          company: "Netflix Inc.", companyURL: "https://www.netflix.com/",
           w3cid: "46379" }
       ],
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,8 @@
         { name: "Matthew Wolenetz",  mailto:"matt.wolenetz@gmail.com",
           company: "W3C Invited Expert",
           w3cid: "148095" },
-        { name: "Mark Watson", url: "", company: "Netflix Inc.", companyURL: "https://www.netflix.com/" }
+        { name: "Mark Watson", url: "", company: "Netflix Inc.", companyURL: "https://www.netflix.com/",
+          w3cid: "46379" }
       ],
 
       formerEditors: [

--- a/index.html
+++ b/index.html
@@ -19,11 +19,19 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-        { name: "Matthew Wolenetz", mailto: "wolenetz@google.com", url: "", company: "Google Inc.", companyURL: "https://www.google.com/", w3cid: "76912" },
-        { name: "Jerry Smith", url: "", company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Mark Watson", url: "", company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "Aaron Colwell (until April 2015)",  url: "", company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Adrian Bateman (until April 2015)", url: "", company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
+        { name: "Matthew Wolenetz",  mailto:"matt.wolenetz@gmail.com",
+          company: "W3C Invited Expert",
+          w3cid: "148095" },
+        { name: "Mark Watson", url: "", company: "Netflix Inc.", companyURL: "https://www.netflix.com/" }
+      ],
+
+      formerEditors: [
+        { name: "Jerry Smith", note: "Until September 2017", url: "",
+          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
+        { name: "Aaron Colwell", note: "Until April 2015",  url: "",
+          company: "Google Inc.", companyURL: "https://www.google.com/" },
+        { name: "Adrian Bateman", note: "Until April 2015", url: "",
+          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       ],
 
       github: "w3c/mse-byte-stream-format-isobmff",
@@ -55,8 +63,7 @@
 
     <section id="sotd">
       <p>The working group maintains <a href="https://github.com/w3c/mse-byte-stream-format-isobmff/issues">a list of all bug reports that the editors have not yet tried to address</a>;
-      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
+      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a> of the [[[MEDIA-SOURCE]]] specification.</p>
     </section>
 
     <section id="introduction">

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           w3cid: "148095" },
         { name: "Mark Watson",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/",
-          w3cid: "46379" }
+          w3cid: "46379" },
       ],
 
       formerEditors: [


### PR DESCRIPTION
Updates needed so that the Media WG can start publishing updates again:

- Moved editors who are no longer in the group to the list of former editors.
- Dropped the paragraph about unstability before Candidate Recommendation stage from the Status of This Document section, as it does not apply to a Note.
- Completed the link to the GitHub repository of MSE.

@wolenetz, @mwatson2, I'm assuming you're fine to continue being listed as editors of the spec (and note I'll prepare similar updates to the other byte stream format specs).